### PR TITLE
Pass link assignments

### DIFF
--- a/lib/mazurka/resource/link.ex
+++ b/lib/mazurka/resource/link.ex
@@ -23,6 +23,7 @@ defmodule Mazurka.Resource.Link do
     opts = format_opts(opts)
     Module.put_attribute(__CALLER__.module, :mazurka_links, resource)
 
+    mod = __CALLER__.module
     quote do
       conn = var!(conn)
       router = unquote(Utils.router)
@@ -38,7 +39,8 @@ defmodule Mazurka.Resource.Link do
 
       module = Mazurka.Router.resolve_resource(router, resource, source, conn)
 
-      opts = unquote(opts)
+      opts = Mazurka.Resource.Utils.Scope.dump_as_ob(unquote(mod)) |> Map.merge(unquote(opts))
+
       warn = Map.get(opts, :warn)
 
       case module do

--- a/lib/mazurka/resource/utils/global.ex
+++ b/lib/mazurka/resource/utils/global.ex
@@ -12,6 +12,13 @@ defmodule Mazurka.Resource.Utils.Global do
         Mazurka.Resource.Utils.unquote(var_name)()
       end
 
+      defmacro has(name) when is_atom(name) do
+        value = Mazurka.Resource.Utils.unquote(var_name)()
+        quote do
+          unquote(value) |> Map.has_key?(unquote(name))
+        end
+      end
+
       case type do
         :binary ->
           defmacro get(name) when is_atom(name) do

--- a/lib/mazurka/resource/utils/scope.ex
+++ b/lib/mazurka/resource/utils/scope.ex
@@ -130,11 +130,23 @@ defmodule Mazurka.Resource.Utils.Scope do
     end) |> Enum.map(fn {:assignment, x} -> x end)
   end
 
+  defmacro dump_as_ob(mod) do
+    scope = Module.get_attribute(mod, :mazurka_scope) |> assignments
+
+    kvs = scope |> Enum.map(fn {n, _v} -> n end) |> Enum.uniq |> Enum.map(fn k ->
+      {k, Macro.var(k, nil)}
+    end)
+
+    # create a map of %{var_name as atom -> var name}
+    {:%{}, [], kvs}
+  end
+
   defmacro dump() do
     scope = Module.get_attribute(__CALLER__.module, :mazurka_scope) |> assignments
 
     vars = Enum.map(scope, fn({n, _}) -> Macro.var(n, nil) end)
     assigns = Enum.map(scope, fn({n, _}) -> quote(do: _ = unquote(Macro.var(n, nil))) end)
+
     quote do
       var!(conn) = unquote(Utils.conn)
       _ = var!(conn)


### PR DESCRIPTION
This sends all assignments (inputs, params, lets) into the options of a `link_to` so that the destination route can optionally make use of them.

This also adds `Option.has/1` allows the ability to distinguish between an option that was passed and is equal to nil vs an option that was not passed.