### PR TITLE
Add param information to logger metadata, in case of errors.

### DIFF
--- a/lib/mazurka/resource/utils/scope.ex
+++ b/lib/mazurka/resource/utils/scope.ex
@@ -101,6 +101,13 @@ defmodule Mazurka.Resource.Utils.Scope do
       defp __mazurka_scope_check__(resource_type, unquote(Utils.mediatype), unquote_splicing(Utils.arguments)) do
         var!(conn) = unquote(Utils.conn)
         _ = var!(conn)
+
+        unquote(Utils.params) |> Enum.to_list()
+        |> Enum.map(fn {k, v} -> {k |> String.to_atom(), v |> to_string()} end) |> case do
+            [] -> :ok
+            xs -> xs |> Logger.metadata()
+          end
+
         mazurka_error__ = :no_error
         unquote_splicing(scope_splice)
         {mazurka_error__, {unquote_splicing(map)}}


### PR DESCRIPTION
This automatically adds all `param` metadata to logger.  This is so that we can not log every request, but still, if an error happens we will have information about what occurred.  This data will also end up in sentry which could be useful.